### PR TITLE
Make TS declaration match exclude code and readme

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 export default function syncDirectory(srcDir: string, targetDir: string, options?: {
     type?: string;
     forceSync?(filePath?: string): boolean;
-    exclude?: Array<string | RegExp | Function>;
+    exclude?: string | RegExp | Array<string | RegExp | Function>;
     watch?: boolean;
     deleteOrphaned?: boolean;
     supportSymlink?: boolean;


### PR DESCRIPTION
I originally wanted to nuke the ReadMe, as the declaration is more canonical than the code or the ReadMe... but saner heads prevailed. 